### PR TITLE
fix(editor): remove old react-jss type from editor story

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build:watch": "yarn build -w",
     "build-storybook": "build-storybook",
     "clean-storybook": "rm -rf storybook-static",
-    "deploy-storybook": "yarn build-storybook && yarn storybook-to-ghpages -- --existing-output-dir=storybook-static",
+    "deploy-storybook": "yarn clean-storybook && yarn build-storybook && yarn storybook-to-ghpages -- --existing-output-dir=storybook-static",
     "semantic-release": "semantic-release"
   },
   "dependencies": {

--- a/src/components/organisms/editor/editor.stories.tsx
+++ b/src/components/organisms/editor/editor.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { EditorState } from 'draft-js';
-import { ClassNameMap } from 'react-jss';
 
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean, text } from '@storybook/addon-knobs';
@@ -14,7 +13,6 @@ import HtmlDisplay from '../htmlDisplay';
 import README from './README.md';
 
 interface Props {
-  classes?: ClassNameMap<string>;
   editorState?: EditorState;
   placeholder?: string;
   disabled?: boolean;


### PR DESCRIPTION
This fixes github pages deployment which failed due to an old react-jss type. 