### PR TITLE
chore(compile): disable source maps

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,7 +7,6 @@
     "module": "commonjs",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
     "strict": true,
     "noImplicitAny": false,
     "strictNullChecks": true,


### PR DESCRIPTION
Source maps point to non-existent `sources` files when `react-helium` is installed as a dependency.

I might have overlooked something, but this seems to reduce package size.